### PR TITLE
Updating labels to indicate 60 minutes workers invocations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "algoworld-explorer",
   "description": "Open source version of AlgoWorldExplorer powered by Algorand ⚡️",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "author": "AlgoWorld <info@algoworld.io>",
   "license": "GPL-3.0",

--- a/src/components/Dialogs/AboutDialog.tsx
+++ b/src/components/Dialogs/AboutDialog.tsx
@@ -49,7 +49,7 @@ export default function AboutDialog({ open, changeState }: Props) {
         aria-describedby="scroll-dialog-description"
       >
         <DialogTitle color={`primary`} id="scroll-dialog-title">
-          AlgoWorld Explorer v0.1.0
+          AlgoWorld Explorer v0.1.1
         </DialogTitle>
         <DialogContent dividers={true}>
           <DialogContentText ref={descriptionElementRef} tabIndex={-1}>

--- a/src/components/Dialogs/ConfirmPackPurchaseDialog.tsx
+++ b/src/components/Dialogs/ConfirmPackPurchaseDialog.tsx
@@ -155,7 +155,7 @@ const ConfirmPackPurchaseDialog = ({
           (!swapIsActiveState.loading && !swapIsActive)) && (
           <Typography variant="h6" color={`warning.main`}>
             Sorry this pack was recently purchased. The pack will be moved to
-            purchased tab within next 30 minutes.
+            purchased tab within next 60 minutes.
           </Typography>
         )}
         {hasNoBalanceForAssets && (

--- a/src/components/Dialogs/DepositInfluenceDialog.tsx
+++ b/src/components/Dialogs/DepositInfluenceDialog.tsx
@@ -89,7 +89,7 @@ export const DepositInfluenceDialog = ({
           >
             {`By pressing Deposit, you are going to deposit city influence in AWT
             tokens for ${depositAsset.name} (${depositAsset.index}).
-            Please note that it will take up to 30 minutes until ARC69 tag is
+            Please note that it will take up to 60 minutes until ARC69 tag is
             updated by the manager wallet after deposit is performed.`}
           </DialogContentText>
           {` `}

--- a/src/pages/leaderboard.page.tsx
+++ b/src/pages/leaderboard.page.tsx
@@ -152,7 +152,7 @@ const Leaderboard = () => {
     }
 
     enqueueSnackbar(
-      `Deposit of AWT for asset ${assetIndex} was performed. Please refer to My Transactions page to see your pending transactions. Manager wallet will update the ARC 69 tags within 30 minutes to reflect your deposit, please wait...`,
+      `Deposit of AWT for asset ${assetIndex} was performed. Please refer to My Transactions page to see your pending transactions. Manager wallet will update the ARC 69 tags within 60 minutes to reflect your deposit, please wait...`,
       {
         variant: `success`,
         action: () => (

--- a/src/utils/transactions/createInfluenceDepositTxns.ts
+++ b/src/utils/transactions/createInfluenceDepositTxns.ts
@@ -45,7 +45,7 @@ export default async function createInfluenceDepositTxns(
       amount: fundingFee,
       note: new Uint8Array(
         Buffer.from(
-          `I am a fee transaction for covering a fee that will be spend by manager wallet to update ARC69 tag within next 30 minutes :-)`,
+          `I am a fee transaction for covering a fee that will be spend by manager wallet to update ARC69 tag within next 60 minutes :-)`,
         ),
       ),
       suggestedParams,


### PR DESCRIPTION
### Description

> _Please explain the changes you made here_

Workers now run every hours to reduce compute cost on 2000 compute minutes per month for github actions. 
https://github.com/AlgoWorldNFT/algoworld-workers/commit/457d846ff660b33b9f21a3b66f662d1677127db3

### Checklist

> _Please, make sure to comply with the checklist below before expecting review_

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
